### PR TITLE
fix: Add a "no value" display for Ryanair and Jet2

### DIFF
--- a/grafana_dashboard.json
+++ b/grafana_dashboard.json
@@ -727,6 +727,7 @@
             "mode": "thresholds"
           },
           "mappings": [],
+          "noValue": "No Ryanair Aircraft",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -795,6 +796,7 @@
             "mode": "thresholds"
           },
           "mappings": [],
+          "noValue": "No Jet2 Aircraft",
           "thresholds": {
             "mode": "absolute",
             "steps": [


### PR DESCRIPTION
Hello,
Quick fix here: the Grafana dashboard wasn't properly handling missing data for Ryanair and Jet2.

P.S. This tool is very wonderful! Thank you very much for developing and maintaining this tool!